### PR TITLE
[#2] ✅ Read profile name from command line args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 # For Git-Config-Manager
 profiles.cfg
+
+# For me
+temp.py

--- a/config_manager.py
+++ b/config_manager.py
@@ -1,6 +1,7 @@
 from typing import Iterable
 import configparser
 import os
+import argparse
 
 
 class config_manager:
@@ -26,5 +27,9 @@ class config_manager:
                 os.system(cmd)
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("profile_name", help="Enter the name of profile you"
+                        " want to apply")
+    args = parser.parse_args()
     cfmgr = config_manager()
-    cfmgr.set_profile("home")
+    cfmgr.set_profile(args.profile_name)

--- a/config_manager.py
+++ b/config_manager.py
@@ -26,6 +26,7 @@ class config_manager:
                 print(cmd)
                 os.system(cmd)
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("profile_name", help="Enter the name of profile you"


### PR DESCRIPTION
Closes #2 

Used argparse to read profile_name from command line. Below are the details:
    usage: config_manager.py [-h] profile_name

    positional arguments:
      profile_name  Enter the name of profile you want to apply

    optional arguments:
      -h, --help    show this help message and exit